### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Stories in Ready](https://badge.waffle.io/JudoPay/Judo-Swift.png?label=ready&title=Ready)](https://waffle.io/JudoPay/Judo-Swift)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/Judo.svg)](https://img.shields.io/cocoapods/v/Judo.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Judo.svg)](https://img.shields.io/cocoapods/v/Judo.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/Carthage/Carthage)
 [![License](https://img.shields.io/cocoapods/l/Judo.svg)](http://http://cocoadocs.org/docsets/Judo)
 [![Platform](https://img.shields.io/cocoapods/p/Judo.svg)](http://http://cocoadocs.org/docsets/Judo)


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
