### PR TITLE
Allow empty paymentData in Simulator

### DIFF
--- a/Source/API/Transaction.swift
+++ b/Source/API/Transaction.swift
@@ -163,7 +163,7 @@ public class Transaction: SessionProtocol {
             } catch {
                  // Allow empty paymentData on simulator for test cards
                  #if !(arch(i386) || arch(x86_64)) && (os(iOS) || os(watchOS) || os(tvOS))
-                     return nil
+                     return
                  #endif
             }
             

--- a/Source/API/Transaction.swift
+++ b/Source/API/Transaction.swift
@@ -161,7 +161,10 @@ public class Transaction: SessionProtocol {
             do {
                 tokenDict["paymentData"] = try NSJSONSerialization.JSONObjectWithData(pkPayment.token.paymentData, options: NSJSONReadingOptions.MutableLeaves) as? JSONDictionary
             } catch {
-                return // BAIL
+                 // Allow empty paymentData on simulator for test cards
+                 #if !(arch(i386) || arch(x86_64)) && (os(iOS) || os(watchOS) || os(tvOS))
+                     return nil
+                 #endif
             }
             
             self.parameters["pkPayment"] = ["token":tokenDict]


### PR DESCRIPTION
Otherwise all tests in the simulator will fail. 